### PR TITLE
 Added budget input and over budget warning to build summary screen

### DIFF
--- a/src/main/java/org/example/pcbuilderapplication/controllers/SummaryController.java
+++ b/src/main/java/org/example/pcbuilderapplication/controllers/SummaryController.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Label;
 import org.example.pcbuilderapplication.DatabaseManager;
 import org.example.pcbuilderapplication.models.BuildSelection;
 import org.example.pcbuilderapplication.models.UserService;
+import javafx.scene.control.TextField;
 
 public class SummaryController {
 
@@ -16,6 +17,8 @@ public class SummaryController {
     @FXML private Label ramLabel;
     @FXML private Label storageLabel;
     @FXML private Label totalLabel;
+    @FXML private TextField budgetField;
+    @FXML private Label budgetLabel;
 
     @FXML
     public void initialize() {
@@ -73,5 +76,35 @@ public class SummaryController {
                 BuildSelection.cpu, BuildSelection.motherboard,
                 BuildSelection.gpu, BuildSelection.ram,
                 BuildSelection.storage, total);
+    }
+
+    @FXML
+    private void checkBudget() {
+        String input = budgetField.getText().trim();
+
+        try {
+            double budget = Double.parseDouble(input);
+            DatabaseManager db = new DatabaseManager();
+
+            double total = db.getPartPrice(BuildSelection.cpu)
+                    + db.getPartPrice(BuildSelection.motherboard)
+                    + db.getPartPrice(BuildSelection.gpu)
+                    + db.getPartPrice(BuildSelection.ram)
+                    + db.getPartPrice(BuildSelection.storage);
+
+            if (total > budget) {
+                double over = total - budget;
+                budgetLabel.setText(String.format("Over budget by $%.2f!", over));
+                budgetLabel.setStyle("-fx-text-fill: #e74c3c;");
+            } else {
+                double under = budget - total;
+                budgetLabel.setText(String.format("Within budget! $%.2f remaining.", under));
+                budgetLabel.setStyle("-fx-text-fill: #2ecc71;");
+            }
+
+        } catch (NumberFormatException e) {
+            budgetLabel.setText("Please enter a valid number.");
+            budgetLabel.setStyle("-fx-text-fill: #e74c3c;");
+        }
     }
 }

--- a/src/main/resources/org/example/pcbuilderapplication/catalog.fxml
+++ b/src/main/resources/org/example/pcbuilderapplication/catalog.fxml
@@ -45,18 +45,10 @@
             <VBox spacing="14" alignment="CENTER" maxWidth="320" prefWidth="320">
 
                 <Button fx:id="fetchGpuBtn"
-                  text="Fetch GPUs from Web"
-                  onAction="#fetchGpusFromApi"
-                  prefWidth="320"
-                  styleClass="login-btn"/>
-
-                <Label fx:id="apiStatusLabel" text=""/>
-
-                <Label fx:id="compatibilityLabel"
-                       text=""
-                       styleClass="warning-text"
-                       wrapText="true"
-                       maxWidth="320"/>
+                        text="Fetch GPUs from Web"
+                        onAction="#fetchGpusFromApi"
+                        prefWidth="320"
+                        styleClass="login-btn"/>
 
                 <Button text="NEXT"
                         styleClass="login-btn"
@@ -67,6 +59,14 @@
                         styleClass="login-btn"
                         onAction="#goHome"
                         prefWidth="320"/>
+
+                <Label fx:id="apiStatusLabel" text=""/>
+
+                <Label fx:id="compatibilityLabel"
+                       text=""
+                       styleClass="warning-text"
+                       wrapText="true"
+                       maxWidth="320"/>
             </VBox>
 
         </VBox>

--- a/src/main/resources/org/example/pcbuilderapplication/login.css
+++ b/src/main/resources/org/example/pcbuilderapplication/login.css
@@ -1,5 +1,5 @@
 /*
-   PC Builder App — Login Screen
+   PC Builder App — Login Screen Theme
 */
 
 .root-pane {

--- a/src/main/resources/org/example/pcbuilderapplication/login.fxml
+++ b/src/main/resources/org/example/pcbuilderapplication/login.fxml
@@ -29,7 +29,7 @@
         <VBox styleClass="card-content" alignment="CENTER" spacing="24">
 
             <VBox alignment="CENTER" spacing="6">
-                <Label text="Welcome Back" styleClass="headline"/>
+                <Label text="Welcome" styleClass="headline"/>
                 <Label text="Sign in to your builder account" styleClass="subheadline"/>
             </VBox>
 

--- a/src/main/resources/org/example/pcbuilderapplication/summary.fxml
+++ b/src/main/resources/org/example/pcbuilderapplication/summary.fxml
@@ -42,6 +42,18 @@
                 <Pane styleClass="divider"/>
 
                 <Label fx:id="totalLabel" text="Total: $0" styleClass="headline"/>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <TextField fx:id="budgetField"
+                               promptText="Enter your budget"
+                               styleClass="input-field"
+                               prefWidth="200"/>
+                    <Button text="CHECK"
+                            styleClass="login-btn"
+                            onAction="#checkBudget"
+                            prefWidth="90"/>
+                </HBox>
+
+                <Label fx:id="budgetLabel" text="" styleClass="subheadline" wrapText="true"/>
             </VBox>
 
             <VBox spacing="14" alignment="CENTER" maxWidth="320" prefWidth="320">


### PR DESCRIPTION
Allow users to enter a budget on the summary screen and compare it against their build's total cost. Displays a green confirmation and shows what is left over or a red warning showing how much they are over.